### PR TITLE
Fix runtime error when API returns null

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useEffect, useState } from "react";
 import { AgentPanel } from "@/components/agent-panel";
 import { Chat } from "@/components/chat";
@@ -21,6 +20,8 @@ export default function Home() {
   useEffect(() => {
     (async () => {
       const data = await callChatAPI("", conversationId ?? "");
+      if (!data) return;
+      
       setConversationId(data.conversation_id);
       setCurrentAgent(data.current_agent);
       setContext(data.context);
@@ -58,6 +59,11 @@ export default function Home() {
     setIsLoading(true);
 
     const data = await callChatAPI(content, conversationId ?? "");
+    
+    if (!data) {
+      setIsLoading(false);
+      return;
+    }
 
     if (!conversationId) setConversationId(data.conversation_id);
     setCurrentAgent(data.current_agent);


### PR DESCRIPTION
 This addresses the runtime error "Cannot read properties of null (reading 'conversation_id')" that occurs when the API call fails and returns null.
Changes made:
Added null check after the initial API call in the useEffect hook
Added null check in the handleSendMessage function before accessing data properties
These changes prevent the application from crashing when the backend API is unavailable or returns an error response.