### PR TITLE
feat: Add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,35 @@ This flow demonstrates how the system not only routes requests to the appropriat
 
 There are two mock itineraries so both scenarios continue to work: the disrupted Paris -> New York -> Austin trip (PA441/NY802 with rebook to NY950) and the existing on-time flight (FLT-123) used in the first two demo flows.
 
+## Using Astraflow as the AI provider
+
+[Astraflow](https://astraflow.ucloud.cn/) (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform that supports 200+ models. Because it exposes the same REST interface as the OpenAI API, you can use it as a drop-in replacement without changing any agent or tool code.
+
+### Endpoints
+
+| Region | Base URL | Environment variable |
+|---|---|---|
+| Global (US / CA) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
+| China | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |
+
+Sign up for an API key at <https://astraflow.ucloud.cn/>.
+
+### Setup
+
+Export **one** of the following environment variables before starting the backend:
+
+```bash
+# Global endpoint (US / CA)
+export ASTRAFLOW_API_KEY=your_astraflow_api_key
+
+# — or — China endpoint
+export ASTRAFLOW_CN_API_KEY=your_astraflow_cn_api_key
+```
+
+When either variable is present the backend automatically routes all model calls through Astraflow. If neither variable is set the app falls back to the standard `OPENAI_API_KEY` flow described above.
+
+> **Note:** `ASTRAFLOW_CN_API_KEY` takes precedence over `ASTRAFLOW_API_KEY` when both are set.
+
 ## Contributing
 
 You are welcome to open issues or submit PRs to improve this app, however, please note that we may not review all suggestions.

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -4,6 +4,9 @@ import json
 import os
 from typing import Any, Dict
 
+from openai import AsyncOpenAI
+from agents import set_default_openai_client
+
 from chatkit.server import StreamingResult
 from fastapi import Depends, FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -26,6 +29,28 @@ from airline.context import (
 from server import AirlineServer
 
 app = FastAPI()
+
+# ---------------------------------------------------------------------------
+# Astraflow provider support (OpenAI-compatible)
+# Priority: ASTRAFLOW_CN_API_KEY (China) > ASTRAFLOW_API_KEY (Global)
+# Falls back to the standard OpenAI client when neither key is set.
+# Sign up: https://astraflow.ucloud.cn/
+# ---------------------------------------------------------------------------
+_astraflow_cn_key = os.environ.get("ASTRAFLOW_CN_API_KEY")
+_astraflow_key = os.environ.get("ASTRAFLOW_API_KEY")
+
+if _astraflow_cn_key:
+    _astraflow_client = AsyncOpenAI(
+        api_key=_astraflow_cn_key,
+        base_url="https://api.modelverse.cn/v1",
+    )
+    set_default_openai_client(_astraflow_client)
+elif _astraflow_key:
+    _astraflow_client = AsyncOpenAI(
+        api_key=_astraflow_key,
+        base_url="https://api-us-ca.umodelverse.ai/v1",
+    )
+    set_default_openai_client(_astraflow_client)
 
 # Disable tracing for zero data retention orgs
 os.environ.setdefault("OPENAI_TRACING_DISABLED", "1")


### PR DESCRIPTION
## Add Astraflow Provider Support

[Astraflow](https://astraflow.ucloud.cn/) (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform that supports 200+ models. Because it exposes the same REST interface as the OpenAI API, it can be wired in by simply pointing the `AsyncOpenAI` client at the appropriate base URL — no changes to agent logic or tool code are required.

### What changed

| File | Change |
|---|---|
| `python-backend/main.py` | Auto-detect `ASTRAFLOW_API_KEY` (global) or `ASTRAFLOW_CN_API_KEY` (China) at startup and, when present, replace the default OpenAI client used by the Agents SDK with one that targets the matching Astraflow endpoint. Falls back to the standard OpenAI client when neither key is set. |
| `python-backend/requirements.txt` | No new dependencies — `openai` is already pulled in transitively by `openai-agents`. |
| `README.md` | Added an **"Using Astraflow as the AI provider"** section documenting both endpoints, the env vars, and a link to sign up. |

### Endpoints

| Region | Base URL | Env var |
|---|---|---|
| Global (US/CA) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

### How to use

```bash
# Global endpoint
export ASTRAFLOW_API_KEY=your_astraflow_key

# — or — China endpoint
export ASTRAFLOW_CN_API_KEY=your_astraflow_cn_key

cd python-backend
python -m uvicorn main:app --reload --port 8000
```

When either key is present the backend will automatically route all model calls through Astraflow instead of OpenAI. Sign up at https://astraflow.ucloud.cn/.
