### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,29 @@ It is composed of two parts:
 
 ## How to use
 
+### Using Astraflow as the AI provider
+
+[Astraflow](https://astraflow.ucloud.cn/) (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform that supports 200+ models. Because it speaks the OpenAI API, it works as a transparent drop-in replacement — no code changes are required beyond setting the appropriate environment variable.
+
+**Global endpoint** (`ASTRAFLOW_API_KEY`)
+```bash
+export ASTRAFLOW_API_KEY=your_astraflow_api_key
+```
+
+**China endpoint** (`ASTRAFLOW_CN_API_KEY`)
+```bash
+export ASTRAFLOW_CN_API_KEY=your_astraflow_cn_api_key
+```
+
+You can optionally override the model (defaults to `gpt-4o` when using Astraflow):
+```bash
+export ASTRAFLOW_MODEL=deepseek-v3   # any of the 200+ models on the platform
+```
+
+Sign up for an API key at <https://astraflow.ucloud.cn/>.
+
+When neither `ASTRAFLOW_API_KEY` nor `ASTRAFLOW_CN_API_KEY` is set, the app falls back to the standard OpenAI key described below.
+
 ### Setting your OpenAI API key
 
 You can set your OpenAI API key in your environment variables by running the following command in your terminal:

--- a/python-backend/airline/agents.py
+++ b/python-backend/airline/agents.py
@@ -22,7 +22,23 @@ from .tools import (
     update_seat,
 )
 
-MODEL = "gpt-5.2"
+# ---------------------------------------------------------------------------
+# Model selection
+# When Astraflow credentials are present the ASTRAFLOW_MODEL env var lets
+# operators choose any of the 200+ models on the platform without code changes.
+# Falls back to the OpenAI model used by the rest of the demo.
+# ---------------------------------------------------------------------------
+import os as _os
+
+_ASTRAFLOW_ACTIVE = bool(
+    _os.environ.get("ASTRAFLOW_API_KEY") or _os.environ.get("ASTRAFLOW_CN_API_KEY")
+)
+
+# Default Astraflow model – can be overridden via the ASTRAFLOW_MODEL env var.
+_ASTRAFLOW_DEFAULT_MODEL = "gpt-4o"
+ASTRAFLOW_MODEL: str = _os.environ.get("ASTRAFLOW_MODEL", _ASTRAFLOW_DEFAULT_MODEL)
+
+MODEL = ASTRAFLOW_MODEL if _ASTRAFLOW_ACTIVE else "gpt-5.2"
 
 
 def seat_services_instructions(

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -4,6 +4,9 @@ import json
 import os
 from typing import Any, Dict
 
+from openai import AsyncOpenAI
+from agents import set_default_openai_client
+
 from chatkit.server import StreamingResult
 from fastapi import Depends, FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -26,6 +29,32 @@ from airline.context import (
 from server import AirlineServer
 
 app = FastAPI()
+
+# ---------------------------------------------------------------------------
+# Astraflow provider support
+# Astraflow (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation
+# platform supporting 200+ models.  When an Astraflow API key is present it is
+# registered as the default OpenAI client so every agent transparently uses it.
+#
+# Global endpoint  : https://api-us-ca.umodelverse.ai/v1  (ASTRAFLOW_API_KEY)
+# China  endpoint  : https://api.modelverse.cn/v1         (ASTRAFLOW_CN_API_KEY)
+# Sign-up          : https://astraflow.ucloud.cn/
+# ---------------------------------------------------------------------------
+_ASTRAFLOW_API_KEY = os.environ.get("ASTRAFLOW_API_KEY", "")
+_ASTRAFLOW_CN_API_KEY = os.environ.get("ASTRAFLOW_CN_API_KEY", "")
+
+if _ASTRAFLOW_API_KEY:
+    _astraflow_client = AsyncOpenAI(
+        api_key=_ASTRAFLOW_API_KEY,
+        base_url="https://api-us-ca.umodelverse.ai/v1",
+    )
+    set_default_openai_client(_astraflow_client)
+elif _ASTRAFLOW_CN_API_KEY:
+    _astraflow_client = AsyncOpenAI(
+        api_key=_ASTRAFLOW_CN_API_KEY,
+        base_url="https://api.modelverse.cn/v1",
+    )
+    set_default_openai_client(_astraflow_client)
 
 # Disable tracing for zero data retention orgs
 os.environ.setdefault("OPENAI_TRACING_DISABLED", "1")


### PR DESCRIPTION
## Summary

This PR adds first-class support for [Astraflow](https://astraflow.ucloud.cn/) (by UCloud / 优刻得) as an OpenAI-compatible AI provider.

Astraflow is a model aggregation platform that exposes 200+ models through an OpenAI-compatible API, making it a drop-in replacement for the OpenAI client already used by the `openai-agents` SDK.

### What changed

| File | Change |
|---|---|
| `python-backend/main.py` | Auto-detect `ASTRAFLOW_API_KEY` / `ASTRAFLOW_CN_API_KEY` and register the matching `AsyncOpenAI` client as the SDK default via `set_default_openai_client()` |
| `python-backend/airline/agents.py` | Expose `ASTRAFLOW_MODEL` constant (defaults to `gpt-4o`) and use it when Astraflow credentials are detected; fall back to the existing `MODEL` constant otherwise |
| `python-backend/requirements.txt` | No new dependencies — Astraflow reuses the `openai` package already pulled in by `openai-agents` |
| `README.md` | Document both Astraflow endpoints, env vars, and the model override env var |

### How it works

The `openai-agents` SDK honours whatever client is registered with `set_default_openai_client()`.  
On startup `main.py` checks for the Astraflow env vars in priority order:

1. `ASTRAFLOW_API_KEY` → global endpoint `https://api-us-ca.umodelverse.ai/v1`
2. `ASTRAFLOW_CN_API_KEY` → China endpoint `https://api.modelverse.cn/v1`
3. Fallback to the existing `OPENAI_API_KEY` behaviour (no change)

An optional `ASTRAFLOW_MODEL` env var lets operators pick any of the 200+ Astraflow models without editing source code.

### Usage

```bash
# Global endpoint
export ASTRAFLOW_API_KEY=your_astraflow_api_key

# OR China endpoint
export ASTRAFLOW_CN_API_KEY=your_astraflow_cn_api_key

# Optional: override the model (defaults to gpt-4o)
export ASTRAFLOW_MODEL=deepseek-v3

cd python-backend
python -m uvicorn main:app --reload --port 8000
```

Sign up for an API key at https://astraflow.ucloud.cn/