### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# ============================================================
+# Environment variables for openai-cs-agents-demo
+# Copy this file to .env and fill in the values you need.
+# ============================================================
+
+# ── Standard OpenAI ─────────────────────────────────────────
+# OPENAI_API_KEY=your_openai_api_key_here
+
+# ── Astraflow (by UCloud / 优刻得) ───────────────────────────
+# OpenAI-compatible platform supporting 200+ models.
+# Sign up: https://astraflow.ucloud-global.com (global)
+#          https://astraflow.ucloud.cn         (China)
+#
+# Global endpoint (outside China):
+# ASTRAFLOW_API_KEY=your_astraflow_api_key_here
+#
+# China endpoint:
+# ASTRAFLOW_CN_API_KEY=your_astraflow_cn_api_key_here
+#
+# Override the model used by all agents when running on Astraflow:
+# ASTRAFLOW_MODEL=gpt-4o
+
+# ── Misc ────────────────────────────────────────────────────
+# Disable OpenAI tracing (already set as default in main.py)
+# OPENAI_TRACING_DISABLED=1

--- a/python-backend/airline/agents.py
+++ b/python-backend/airline/agents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import os
 import random
 import string
 
@@ -22,7 +23,9 @@ from .tools import (
     update_seat,
 )
 
-MODEL = "gpt-5.2"
+# Allow overriding the model via ASTRAFLOW_MODEL (useful when routing through
+# the Astraflow platform which exposes 200+ OpenAI-compatible models).
+MODEL = os.environ.get("ASTRAFLOW_MODEL", "gpt-5.2")
 
 
 def seat_services_instructions(

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -30,6 +30,38 @@ app = FastAPI()
 # Disable tracing for zero data retention orgs
 os.environ.setdefault("OPENAI_TRACING_DISABLED", "1")
 
+# ---------------------------------------------------------------------------
+# Astraflow provider support (OpenAI-compatible, by UCloud / 优刻得)
+# Supports 200+ models via a drop-in OpenAI-compatible endpoint.
+#
+# Global endpoint: set ASTRAFLOW_API_KEY
+#   https://astraflow.ucloud-global.com
+# China  endpoint: set ASTRAFLOW_CN_API_KEY
+#   https://astraflow.ucloud.cn
+#
+# If neither key is set the app falls back to the standard OpenAI client.
+# ---------------------------------------------------------------------------
+_astraflow_api_key = os.environ.get("ASTRAFLOW_API_KEY")
+_astraflow_cn_api_key = os.environ.get("ASTRAFLOW_CN_API_KEY")
+
+if _astraflow_api_key or _astraflow_cn_api_key:
+    import openai
+    from agents import set_default_openai_client
+
+    if _astraflow_api_key:
+        _astraflow_base_url = "https://api-us-ca.umodelverse.ai/v1"
+        _astraflow_key = _astraflow_api_key
+    else:
+        _astraflow_base_url = "https://api.modelverse.cn/v1"
+        _astraflow_key = _astraflow_cn_api_key
+
+    _astraflow_client = openai.AsyncOpenAI(
+        api_key=_astraflow_key,
+        base_url=_astraflow_base_url,
+    )
+    set_default_openai_client(_astraflow_client)
+
+
 # CORS configuration (adjust as needed for deployment)
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary

Adds support for [Astraflow](https://astraflow.ucloud-global.com) — UCloud's OpenAI-compatible AI model aggregation platform supporting 200+ models — as an alternative LLM backend.

Because Astraflow is fully OpenAI-compatible, the integration is minimal:
- Set a custom `base_url` on an `AsyncOpenAI` client and register it via `set_default_openai_client` from the `openai-agents` SDK.
- No new SDK, no new subpackage — just a few lines of configuration.

## Changes

### `python-backend/main.py`
- On startup, if `ASTRAFLOW_API_KEY` (global endpoint) or `ASTRAFLOW_CN_API_KEY` (China endpoint) is set, construct an `openai.AsyncOpenAI` client pointing at the appropriate Astraflow base URL and register it as the default client for the agents SDK. Falls back to standard OpenAI behaviour if neither key is present.

### `python-backend/airline/agents.py`
- The `MODEL` constant now reads from the `ASTRAFLOW_MODEL` environment variable (default: `gpt-5.2`), so users can easily select a different model when using Astraflow without touching the source code.

### `.env.example` (new)
- Documents all supported environment variables for local development.

## Usage

**Global endpoint (outside China):**
```bash
export ASTRAFLOW_API_KEY=your_key_here
export ASTRAFLOW_MODEL=gpt-4o   # optional; defaults to gpt-5.2
cd python-backend && uvicorn main:app --reload
```

**China endpoint:**
```bash
export ASTRAFLOW_CN_API_KEY=your_key_here
cd python-backend && uvicorn main:app --reload
```

Sign up / get an API key:
- Global: https://astraflow.ucloud-global.com
- China:  https://astraflow.ucloud.cn
